### PR TITLE
Add new option "Enable for shipping methods"

### DIFF
--- a/cloudpayments-gateway-for-woocommerce/inc/wc-cloud-payments-gateway.php
+++ b/cloudpayments-gateway-for-woocommerce/inc/wc-cloud-payments-gateway.php
@@ -1,5 +1,11 @@
 <?php
 
+use Automattic\Jetpack\Constants;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
 class WC_CloudPayments_Gateway extends WC_Payment_Gateway
 {
     
@@ -29,29 +35,30 @@ class WC_CloudPayments_Gateway extends WC_Payment_Gateway
         $this->title       = 'CloudPayments';
         $this->description = 'CloudPayments';
         
-        $this->enabled          = $this->get_option('enabled');
-        $this->enabledDMS       = $this->get_option('enabledDMS');
-        $this->DMS_AU_status    = $this->get_option('DMS_AU_status');
-        $this->DMS_CF_status    = $this->get_option('DMS_CF_status');
-        $this->skin             = $this->get_option('skin');
-        $this->language         = $this->get_option('language');
-        $this->status_chancel   = $this->get_option('status_chancel');
-        $this->status_pay       = $this->get_option('status_pay');
-        $this->title            = $this->get_option('title');
-        $this->description      = $this->get_option('description');
-        $this->public_id        = $this->get_option('public_id');
-        $this->api_pass         = $this->get_option('api_pass');
-        $this->currency         = $this->get_option('currency');
-        $this->kassa_enabled    = $this->get_option('kassa_enabled');
-        $this->kassa_taxtype    = $this->get_option('kassa_taxtype');
-        $this->delivery_taxtype = $this->get_option('delivery_taxtype');
-        $this->kassa_taxsystem  = $this->get_option('kassa_taxsystem');
-        $this->kassa_skubarcode = $this->get_option('kassa_skubarcode');
-        $this->kassa_method     = $this->get_option('kassa_method');
-        $this->kassa_object     = $this->get_option('kassa_object');
-        $this->status_delivered = $this->get_option('status_delivered');
-        $this->inn              = $this->get_option('inn');
-        $this->order_text       = $this->get_option('order_text');
+        $this->enabled            = $this->get_option('enabled');
+        $this->enabledDMS         = $this->get_option('enabledDMS');
+        $this->DMS_AU_status      = $this->get_option('DMS_AU_status');
+        $this->DMS_CF_status      = $this->get_option('DMS_CF_status');
+        $this->skin               = $this->get_option('skin');
+        $this->language           = $this->get_option('language');
+        $this->status_chancel     = $this->get_option('status_chancel');
+        $this->status_pay         = $this->get_option('status_pay');
+        $this->title              = $this->get_option('title');
+        $this->description        = $this->get_option('description');
+        $this->public_id          = $this->get_option('public_id');
+        $this->api_pass           = $this->get_option('api_pass');
+        $this->currency           = $this->get_option('currency');
+        $this->kassa_enabled      = $this->get_option('kassa_enabled');
+        $this->kassa_taxtype      = $this->get_option('kassa_taxtype');
+        $this->delivery_taxtype   = $this->get_option('delivery_taxtype');
+        $this->kassa_taxsystem    = $this->get_option('kassa_taxsystem');
+        $this->kassa_skubarcode   = $this->get_option('kassa_skubarcode');
+        $this->kassa_method       = $this->get_option('kassa_method');
+        $this->kassa_object       = $this->get_option('kassa_object');
+        $this->status_delivered   = $this->get_option('status_delivered');
+        $this->inn                = $this->get_option('inn');
+        $this->order_text         = $this->get_option('order_text');
+        $this->enable_for_methods = $this->get_option( 'enable_for_methods', array() );
         
         add_action('woocommerce_receipt_wc_cloudpayments_gateway', array($this, 'payment_page'));
         add_action('woocommerce_update_options_payment_gateways_' . $this->id, array($this, 'process_admin_options'));
@@ -495,6 +502,19 @@ class WC_CloudPayments_Gateway extends WC_Payment_Gateway
                 'label'   => __('Отправлять артикул (SKU) товара как штрих-код', 'woocommerce'),
                 'default' => 'yes'
             ),
+            'enable_for_methods' => array(
+                'title'             => __( 'Enable for shipping methods', 'woocommerce' ),
+                'type'              => 'multiselect',
+                'class'             => 'wc-enhanced-select',
+                'css'               => 'width: 400px;',
+                'default'           => '',
+                'description'       => __( 'Если CloudPayments доступен только для определенных методов доставки, выберите их здесь. Оставьте поле пустым, чтобы включить CloudPayments для всех методов доставки.', 'cloudpayments' ),
+                'options'           => $this->load_shipping_method_options(),
+                'desc_tip'          => true,
+                'custom_attributes' => array(
+                    'data-placeholder' => __( 'Select shipping methods', 'woocommerce' ),
+                ),
+            ),
         );
     }
     
@@ -699,6 +719,198 @@ class WC_CloudPayments_Gateway extends WC_Payment_Gateway
             
         }
         
+    }
+
+    /**
+     * Check If The Gateway Is Available For Use.
+     *
+     * @return bool
+     */
+    public function is_available() {
+        $order          = null;
+        $needs_shipping = false;
+
+        // Test if shipping is needed first.
+        if ( WC()->cart && WC()->cart->needs_shipping() ) {
+            $needs_shipping = true;
+        } elseif ( is_page( wc_get_page_id( 'checkout' ) ) && 0 < get_query_var( 'order-pay' ) ) {
+            $order_id = absint( get_query_var( 'order-pay' ) );
+            $order    = wc_get_order( $order_id );
+
+            // Test if order needs shipping.
+            if ( $order && 0 < count( $order->get_items() ) ) {
+                foreach ( $order->get_items() as $item ) {
+                    $_product = $item->get_product();
+                    if ( $_product && $_product->needs_shipping() ) {
+                        $needs_shipping = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        $needs_shipping = apply_filters( 'woocommerce_cart_needs_shipping', $needs_shipping );
+
+        // Only apply if all packages are being shipped via chosen method.
+        if ( ! empty( $this->enable_for_methods ) && $needs_shipping ) {
+            $order_shipping_items            = is_object( $order ) ? $order->get_shipping_methods() : false;
+            $chosen_shipping_methods_session = WC()->session->get( 'chosen_shipping_methods' );
+
+            if ( $order_shipping_items ) {
+                $canonical_rate_ids = $this->get_canonical_order_shipping_item_rate_ids( $order_shipping_items );
+            } else {
+                $canonical_rate_ids = $this->get_canonical_package_rate_ids( $chosen_shipping_methods_session );
+            }
+
+            if ( ! count( $this->get_matching_rates( $canonical_rate_ids ) ) ) {
+                return false;
+            }
+        }
+
+        return parent::is_available();
+    }
+
+    /**
+     * Checks to see whether or not the admin settings are being accessed by the current request.
+     *
+     * @return bool
+     */
+    private function is_accessing_settings() {
+        if ( is_admin() ) {
+            // phpcs:disable WordPress.Security.NonceVerification
+            if ( ! isset( $_REQUEST['page'] ) || 'wc-settings' !== $_REQUEST['page'] ) {
+                return false;
+            }
+            if ( ! isset( $_REQUEST['tab'] ) || 'checkout' !== $_REQUEST['tab'] ) {
+                return false;
+            }
+            if ( ! isset( $_REQUEST['section'] ) || 'wc_cloudpayments_gateway' !== $_REQUEST['section'] ) {
+                return false;
+            }
+            // phpcs:enable WordPress.Security.NonceVerification
+
+            return true;
+        }
+
+        if ( Constants::is_true( 'REST_REQUEST' ) ) {
+            global $wp;
+            if ( isset( $wp->query_vars['rest_route'] ) && false !== strpos( $wp->query_vars['rest_route'], '/payment_gateways' ) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Loads all of the shipping method options for the enable_for_methods field.
+     *
+     * @return array
+     */
+    private function load_shipping_method_options() {
+        // Since this is expensive, we only want to do it if we're actually on the settings page.
+        if ( ! $this->is_accessing_settings() ) {
+            return array();
+        }
+
+        $data_store = WC_Data_Store::load( 'shipping-zone' );
+        $raw_zones  = $data_store->get_zones();
+
+        foreach ( $raw_zones as $raw_zone ) {
+            $zones[] = new WC_Shipping_Zone( $raw_zone );
+        }
+
+        $zones[] = new WC_Shipping_Zone( 0 );
+
+        $options = array();
+        foreach ( WC()->shipping()->load_shipping_methods() as $method ) {
+
+            $options[ $method->get_method_title() ] = array();
+
+            // Translators: %1$s shipping method name.
+            $options[ $method->get_method_title() ][ $method->id ] = sprintf( __( 'Any &quot;%1$s&quot; method', 'woocommerce' ), $method->get_method_title() );
+
+            foreach ( $zones as $zone ) {
+
+                $shipping_method_instances = $zone->get_shipping_methods();
+
+                foreach ( $shipping_method_instances as $shipping_method_instance_id => $shipping_method_instance ) {
+
+                    if ( $shipping_method_instance->id !== $method->id ) {
+                        continue;
+                    }
+
+                    $option_id = $shipping_method_instance->get_rate_id();
+
+                    // Translators: %1$s shipping method title, %2$s shipping method id.
+                    $option_instance_title = sprintf( __( '%1$s (#%2$s)', 'woocommerce' ), $shipping_method_instance->get_title(), $shipping_method_instance_id );
+
+                    // Translators: %1$s zone name, %2$s shipping method instance name.
+                    $option_title = sprintf( __( '%1$s &ndash; %2$s', 'woocommerce' ), $zone->get_id() ? $zone->get_zone_name() : __( 'Other locations', 'woocommerce' ), $option_instance_title );
+
+                    $options[ $method->get_method_title() ][ $option_id ] = $option_title;
+                }
+            }
+        }
+
+        return $options;
+    }
+
+    /**
+     * Converts the chosen rate IDs generated by Shipping Methods to a canonical 'method_id:instance_id' format.
+     *
+     * @since  3.4.0
+     *
+     * @param  array $order_shipping_items  Array of WC_Order_Item_Shipping objects.
+     * @return array $canonical_rate_ids    Rate IDs in a canonical format.
+     */
+    private function get_canonical_order_shipping_item_rate_ids( $order_shipping_items ) {
+
+        $canonical_rate_ids = array();
+
+        foreach ( $order_shipping_items as $order_shipping_item ) {
+            $canonical_rate_ids[] = $order_shipping_item->get_method_id() . ':' . $order_shipping_item->get_instance_id();
+        }
+
+        return $canonical_rate_ids;
+    }
+
+    /**
+     * Converts the chosen rate IDs generated by Shipping Methods to a canonical 'method_id:instance_id' format.
+     *
+     * @since  3.4.0
+     *
+     * @param  array $chosen_package_rate_ids Rate IDs as generated by shipping methods. Can be anything if a shipping method doesn't honor WC conventions.
+     * @return array $canonical_rate_ids  Rate IDs in a canonical format.
+     */
+    private function get_canonical_package_rate_ids( $chosen_package_rate_ids ) {
+
+        $shipping_packages  = WC()->shipping()->get_packages();
+        $canonical_rate_ids = array();
+
+        if ( ! empty( $chosen_package_rate_ids ) && is_array( $chosen_package_rate_ids ) ) {
+            foreach ( $chosen_package_rate_ids as $package_key => $chosen_package_rate_id ) {
+                if ( ! empty( $shipping_packages[ $package_key ]['rates'][ $chosen_package_rate_id ] ) ) {
+                    $chosen_rate          = $shipping_packages[ $package_key ]['rates'][ $chosen_package_rate_id ];
+                    $canonical_rate_ids[] = $chosen_rate->get_method_id() . ':' . $chosen_rate->get_instance_id();
+                }
+            }
+        }
+
+        return $canonical_rate_ids;
+    }
+
+    /**
+     * Indicates whether a rate exists in an array of canonically-formatted rate IDs that activates this gateway.
+     *
+     * @since  3.4.0
+     *
+     * @param array $rate_ids Rate ids to check.
+     * @return boolean
+     */
+    private function get_matching_rates( $rate_ids ) {
+        // First, match entries in 'method_id:instance_id' format. Then, match entries in 'method_id' format by stripping off the instance ID from the candidates.
+        return array_unique( array_merge( array_intersect( $this->enable_for_methods, $rate_ids ), array_intersect( $this->enable_for_methods, array_unique( array_map( 'wc_get_string_before_colon', $rate_ids ) ) ) ) );
     }
     
 }


### PR DESCRIPTION
Возникла необходимость включать/отключать платёжный шлюз в зависимости от выбранного метода доставки.

Новая опция позволяет выбрать определённые методы доставки для которых будет доступен платёжный шлюз Cloud Payments.

Опция основана на встроенном в WooCommerce платёжном шлюзе [Оплата при доставке (COD)](https://woocommerce.github.io/code-reference/classes/WC-Gateway-COD.html).